### PR TITLE
Add CommonJS bundle to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,15 +10,17 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "scripts": {
     "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
     "build:js": "esbuild src/index.ts --bundle --minify --platform=node --target=node18 --format=esm --external:bottleneck --external:zod --outfile=dist/index.js",
+    "build:cjs": "esbuild src/index.ts --bundle --minify --platform=node --target=node18 --format=cjs --external:bottleneck --external:zod --outfile=dist/index.cjs",
     "build:types": "tsc --project tsconfig.build.json",
-    "build": "npm run clean && npm run build:js && npm run build:types",
+    "build": "npm run clean && npm run build:js && npm run build:cjs && npm run build:types",
     "dev": "tsx src/index.ts",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
## Summary
- add a CommonJS entry to the package exports so `require('liberlc')` resolves to the new bundle
- extend the build pipeline with an esbuild CJS output alongside existing ESM and type artifacts

## Testing
- npm run build
- NODE_PATH=. node -e "const { createRequire } = require('module'); const r = createRequire(process.cwd() + '/dummy.cjs'); console.log(Object.keys(r('liberlc')));"
- NODE_PATH=. node --input-type=module -e "import('liberlc').then(m => console.log(Object.keys(m))).catch(err => { console.error(err); process.exit(1); });"


------
https://chatgpt.com/codex/tasks/task_e_68e2448efd4483269e2f38841ffd2a54