### PR TITLE
Implement smooth per-endpoint rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,15 +10,17 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "scripts": {
     "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
     "build:js": "esbuild src/index.ts --bundle --minify --platform=node --target=node18 --format=esm --external:bottleneck --external:zod --outfile=dist/index.js",
+    "build:cjs": "esbuild src/index.ts --bundle --minify --platform=node --target=node18 --format=cjs --external:bottleneck --external:zod --outfile=dist/index.cjs",
     "build:types": "tsc --project tsconfig.build.json",
-    "build": "npm run clean && npm run build:js && npm run build:types",
+    "build": "npm run clean && npm run build:js && npm run build:cjs && npm run build:types",
     "dev": "tsx src/index.ts",
     "prepublishOnly": "npm run build"
   },

--- a/src/core/limiter.ts
+++ b/src/core/limiter.ts
@@ -1,39 +1,266 @@
-import Bottleneck from "bottleneck";
-import { parseRateHeaders } from "../utils/headers";
+import { clampDelay, parseRateHeaders } from "../utils/headers";
 
-export class RateCoordinator {
-  private readonly limiter: Bottleneck;
-  private readonly rpm: number;
+const DEFAULT_WINDOW_MS = 60_000;
+const MAX_TIMEOUT = 2 ** 31 - 1;
 
-  constructor(rpm = 60) {
-    this.rpm = rpm;
-    this.limiter = new Bottleneck({
-      reservoir: rpm,
-      reservoirRefreshAmount: rpm,
-      reservoirRefreshInterval: 60_000,
-      minTime: 0,
-      maxConcurrent: 1,
-    });
+export type SmoothRateLimiterOptions = {
+  requestsPerMinute?: number;
+  maxConcurrency?: number;
+  minIntervalMs?: number;
+  debug?: boolean;
+};
+
+type QueueTask<T> = {
+  fn: () => Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+export class SmoothRateLimiter {
+  private readonly defaultRpm: number;
+  private readonly maxConcurrency: number;
+  private readonly minInterval: number;
+  private readonly debug: boolean;
+  private readonly baseConcurrency: number;
+
+  private readonly queue: QueueTask<any>[] = [];
+  private running = 0;
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private timerDueTime = 0;
+  private nextAvailableTime = 0;
+
+  private currentInterval: number;
+  private currentConcurrency: number;
+  private windowResetAt?: number;
+  private windowDuration = DEFAULT_WINDOW_MS;
+
+  constructor(options: SmoothRateLimiterOptions = {}) {
+    this.defaultRpm = Math.max(1, options.requestsPerMinute ?? 60);
+    this.maxConcurrency = Math.max(1, options.maxConcurrency ?? 4);
+    this.minInterval = Math.max(0, options.minIntervalMs ?? 0);
+    this.debug = Boolean(options.debug);
+
+    this.currentInterval = this.defaultInterval();
+    this.baseConcurrency = 1;
+    this.currentConcurrency = this.baseConcurrency;
   }
 
   schedule<T>(fn: () => Promise<T>): Promise<T> {
-    return this.limiter.schedule(fn);
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({ fn, resolve, reject });
+      this.log("enqueued", { queued: this.queue.length });
+      this.pump();
+    });
   }
 
   updateFromHeaders(headers: Headers) {
     const rate = parseRateHeaders(headers);
+    const now = Date.now();
+    this.maybeReset(now);
+
+    if (typeof rate.resetSeconds === "number") {
+      const { resetAt, durationMs } = this.resolveReset(rate.resetSeconds, now);
+      if (resetAt) {
+        this.windowResetAt = resetAt;
+        if (durationMs) {
+          this.windowDuration = durationMs;
+        }
+        this.scheduleTimer(Math.max(0, resetAt - now));
+      }
+    }
 
     if (typeof rate.remaining === "number") {
-      this.limiter.updateSettings({
-        reservoir: Math.max(0, rate.remaining),
+      const remaining = Math.max(0, rate.remaining);
+      const tokens = remaining + 1;
+      const resetAt = this.windowResetAt;
+      const timeToReset = resetAt ? Math.max(0, resetAt - now) : this.windowDuration;
+      const interval = this.calculateInterval(tokens, timeToReset || this.windowDuration);
+      this.currentInterval = interval;
+      this.currentConcurrency = this.calculateConcurrency(tokens, timeToReset || this.windowDuration);
+      this.log("headers", {
+        remaining,
+        interval,
+        concurrency: this.currentConcurrency,
+        timeToReset,
       });
     }
 
-    if (typeof rate.resetSeconds === "number") {
-      this.limiter.updateSettings({
-        reservoirRefreshInterval: Math.max(1, rate.resetSeconds * 1000),
-        reservoirRefreshAmount: this.rpm,
+    this.pump();
+  }
+
+  penalize(waitMs: number) {
+    const delay = clampDelay(waitMs);
+    if (delay <= 0) {
+      return;
+    }
+    const target = Date.now() + delay;
+    this.nextAvailableTime = Math.max(this.nextAvailableTime, target);
+    this.scheduleTimer(this.nextAvailableTime - Date.now());
+    this.log("penalize", { delay });
+  }
+
+  private pump() {
+    if (!this.queue.length) {
+      this.clearTimer();
+      return;
+    }
+
+    const now = Date.now();
+    this.maybeReset(now);
+
+    if (this.running >= this.currentConcurrency) {
+      this.scheduleTimer(this.nextAvailableTime - now);
+      return;
+    }
+
+    if (now < this.nextAvailableTime) {
+      this.scheduleTimer(this.nextAvailableTime - now);
+      return;
+    }
+
+    const task = this.queue.shift() as QueueTask<any>;
+    this.running++;
+    const startAt = Math.max(now, this.nextAvailableTime);
+    this.nextAvailableTime = startAt + this.currentInterval;
+    this.log("start", {
+      running: this.running,
+      nextAvailableIn: Math.max(0, this.nextAvailableTime - Date.now()),
+    });
+
+    Promise.resolve()
+      .then(() => task.fn())
+      .then((result) => {
+        this.running--;
+        task.resolve(result);
+        this.log("finish", { running: this.running });
+        this.pump();
+      })
+      .catch((error) => {
+        this.running--;
+        task.reject(error);
+        this.log("error", { running: this.running, error });
+        this.pump();
       });
+  }
+
+  private maybeReset(now: number) {
+    if (this.windowResetAt && now >= this.windowResetAt) {
+      this.log("reset", {});
+      this.windowResetAt = undefined;
+      this.windowDuration = DEFAULT_WINDOW_MS;
+      this.currentInterval = this.defaultInterval();
+      this.currentConcurrency = this.baseConcurrency;
+      this.nextAvailableTime = Math.min(this.nextAvailableTime, now);
+    }
+  }
+
+  private calculateInterval(tokens: number, timeToReset: number) {
+    const duration = Math.max(this.minInterval, timeToReset);
+    const interval = duration / Math.max(1, tokens);
+    return Math.max(this.minInterval, Math.ceil(interval));
+  }
+
+  private calculateConcurrency(tokens: number, timeToReset: number) {
+    if (timeToReset <= 0) {
+      return this.baseConcurrency;
+    }
+    const desiredRatePerMs = tokens / timeToReset;
+    const defaultRatePerMs = 1 / this.defaultInterval();
+    const ratio = desiredRatePerMs / defaultRatePerMs;
+    const concurrency = Math.min(
+      this.maxConcurrency,
+      Math.max(1, Math.round(ratio))
+    );
+    return Math.max(this.baseConcurrency, concurrency);
+  }
+
+  private resolveReset(resetSeconds: number, now: number) {
+    if (!Number.isFinite(resetSeconds)) {
+      return { resetAt: undefined, durationMs: undefined };
+    }
+
+    const seconds = Math.max(0, resetSeconds);
+    const currentSeconds = Math.floor(now / 1000);
+
+    // Heuristic: treat very large values as absolute timestamps.
+    if (seconds > currentSeconds + 5 || seconds > 100_000) {
+      const resetAt = seconds * 1000;
+      const duration = Math.max(this.defaultInterval(), resetAt - now);
+      return { resetAt, durationMs: duration };
+    }
+
+    const duration = seconds * 1000;
+    return { resetAt: now + duration, durationMs: duration || this.windowDuration };
+  }
+
+  private defaultInterval() {
+    return Math.max(this.minInterval, Math.ceil(DEFAULT_WINDOW_MS / this.defaultRpm));
+  }
+
+  private scheduleTimer(ms: number) {
+    const delay = clampDelay(ms);
+    const now = Date.now();
+    const delayOrZero = delay === 0 ? 0 : Math.min(delay, MAX_TIMEOUT);
+    const dueTime = now + delayOrZero;
+
+    if (this.timer) {
+      if (dueTime >= this.timerDueTime - 5) {
+        return;
+      }
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+
+    this.timerDueTime = dueTime;
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      this.timerDueTime = 0;
+      this.pump();
+    }, delayOrZero);
+  }
+
+  private clearTimer() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+      this.timerDueTime = 0;
+    }
+  }
+
+  private log(event: string, payload: Record<string, unknown>) {
+    if (!this.debug) return;
+    // eslint-disable-next-line no-console
+    console.debug(`[SmoothRateLimiter] ${event}`, payload);
+  }
+}
+
+export type RateLimiterManagerOptions = SmoothRateLimiterOptions;
+
+export class RateLimiterManager {
+  private readonly limiters = new Map<string, SmoothRateLimiter>();
+  private readonly options: SmoothRateLimiterOptions;
+
+  constructor(options: RateLimiterManagerOptions = {}) {
+    this.options = options;
+  }
+
+  forPath(path: string): SmoothRateLimiter {
+    const key = this.normalizePath(path);
+    let limiter = this.limiters.get(key);
+    if (!limiter) {
+      limiter = new SmoothRateLimiter(this.options);
+      this.limiters.set(key, limiter);
+    }
+    return limiter;
+  }
+
+  private normalizePath(path: string) {
+    try {
+      const url = new URL(path, "https://placeholder.local");
+      return url.pathname || "/";
+    } catch {
+      const [clean] = path.split("?");
+      return clean || "/";
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,14 @@ export class PRC {
 
 export { HttpClient, HttpError };
 export type { HttpClientOptions };
+export {
+  SmoothRateLimiter,
+  RateLimiterManager,
+} from "./core/limiter";
+export type {
+  SmoothRateLimiterOptions,
+  RateLimiterManagerOptions,
+} from "./core/limiter";
 export { parseRateHeaders } from "./utils/headers";
 
 export {

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -4,6 +4,8 @@ export type RateHeaders = {
   retryAfterSeconds?: number;
 };
 
+const MAX_TIMEOUT = 2 ** 31 - 1;
+
 export function parseRateHeaders(h: Headers): RateHeaders {
   const remaining = num(h.get("x-ratelimit-remaining"));
   const resetSeconds = num(h.get("x-ratelimit-reset"));
@@ -17,6 +19,17 @@ function num(v: string | null): number | undefined {
   return Number.isFinite(n) ? n : undefined;
 }
 
+export function clampDelay(ms: number | undefined | null): number {
+  if (typeof ms !== "number" || !Number.isFinite(ms) || ms <= 0) {
+    return 0;
+  }
+  return Math.min(MAX_TIMEOUT, Math.max(0, Math.floor(ms)));
+}
+
 export function sleep(ms: number) {
-  return new Promise((r) => setTimeout(r, ms));
+  const delay = clampDelay(ms);
+  if (delay === 0) {
+    return Promise.resolve();
+  }
+  return new Promise((r) => setTimeout(r, delay));
 }


### PR DESCRIPTION
## Summary
- introduce SmoothRateLimiter and RateLimiterManager for adaptive, per-endpoint throttling with automatic window resets
- refactor HttpClient to use the new limiters, add retry penalties, ETag caching enhancements, and optional debug logging
- clamp timeout handling in header utilities and re-export limiter utilities from the public entry point

## Testing
- npm run build
- NODE_PATH=. node -e "const { createRequire } = require('module'); const r = createRequire(process.cwd() + '/dummy.cjs'); console.log(Object.keys(r('liberlc')));"
- NODE_PATH=. node --input-type=module -e "import('liberlc').then(m => console.log(Object.keys(m))).catch(err => { console.error(err); process.exit(1); });"


------
https://chatgpt.com/codex/tasks/task_e_68e2448efd4483269e2f38841ffd2a54